### PR TITLE
Initial setup for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,2 @@
+language: java
+script: mnv clean install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,2 @@
 language: java
-script: mnv clean install
+script: mvn clean install

--- a/README.md
+++ b/README.md
@@ -1,15 +1,16 @@
 # Drools Fiddle
-### Overview
-----------------
+
+## Overview
+
 Drools Fiddle is the fiddle for Drools, a business rule engine maintained by Redhat: https://www.drools.org/. The goal of this web tool is to allow technical or non technical users to play around with Drools. First, it allows you to build your business configuration by defining both fact models and business rules. Secondly, you can simulate the evaluation of your rule package by dynamically instanciating facts in the Drools working memory and trigger the fireAllRules method. A set of features have been implemented in order to enhance the user experience: step by step debugging, contribution, graphical visualization.
 
-# Table of contents
-----------------
+## Table of Contents
+
   - [Overview](#overview)
   - [Table of Contents](#table-of-contents)
-  - Installation
+  - [Install](#install)
     - [Prerequisites](#prerequisites)
-    - [Building](#building)
+    - [Build](#build)
     - [Run integration tests](#run-integration-test)
     - [Docker](#docker)
   - [Getting Started](#getting-started)
@@ -17,29 +18,38 @@ Drools Fiddle is the fiddle for Drools, a business rule engine maintained by Red
   - [Authors](#authors)
   - [License](#license)
 
-## Installation
-This project uses Jboss WildFly as Application Server
+## Install
+
+This project uses [Jboss WildFly](https://wildfly.org) as Application Server.
+
 ### Prerequisites
+
 In order to build and deploy this project you will need to fullfill those prerequisites:
-* All WildFly prerequisites: [https://docs.jboss.org/wildfly/plugins/maven/latest/dependencies.html](https://docs.jboss.org/wildfly/plugins/maven/latest/dependencies.html) 
+* All WildFly prerequisites: [https://docs.jboss.org/wildfly/plugins/maven/latest/dependencies.html](https://docs.jboss.org/wildfly/plugins/maven/latest/dependencies.html)
     * Maven version > 3.1.1
     * Java 8
-*  Docker daemon
+*  [Docker](https://www.docker.com) daemon
 
-### Building
+### Build
+
     mvn clean install
 
 ### Run integration tests
+
     mvn clean verify -Parq-wildfly-managed
-    
+
 ### Docker
+
 #### Build & Deploy
+
     mvn clean install -Pdocker
-    
+
 #### Stop containers
+
     mvn docker:stop -Pdocker
-    
+
 ## Getting Started
+
 1. Connect to http://droolsfiddle.tk/. The DRL editor is already filled with an HelloWorld package:
 
 ```
@@ -55,27 +65,32 @@ then
 end
 ```
 
-2. Click on the **Build** in order to trigger the compilation and build of the rule package
-3. Insert an instance of _Fact_ with 42 as a value and then **Submit**
+2. Click on the **Build** in order to trigger the compilation and build of the rule package.
+3. Insert an instance of _Fact_ with 42 as a value and then **Submit**.
 4. Click on **Fire** in order to trigger the fireAllRules method and evaluate your ruleset.
 
 ## Contributing
+
 1. Fork it!
 2. Create your feature branch: `git checkout -b my-new-feature`
 3. Commit your changes: `git commit -am 'Add some feature'`
 4. Push to the branch: `git push origin my-new-feature`
-5. Submit a pull request 
+5. Submit a pull request.
 
 ## Authors
+
 ### Core team
+
 * Julien Vipret : julien.vipret [at] gmail [dot] com
 * Matteo Casalino : matteo.casalino [at] gmail [dot] com
 
 ### Contributors
+
 * Thomas Palandri
 * Jaona Ramahaleo
 
 ## License
+
 Copyright 2016 Drools Fiddle
 
 Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Initial setup for Travis CI.

- Added ``.travis.yml`` file.
- Cleaned ``README.md`` file.

For further information about activation on this repository, please refer to the [Travis CI documentation](https://docs.travis-ci.com).