### PR TITLE
Quick fix: Waiting for logs to detach the container. Changed log mess…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -339,7 +339,7 @@
                                     <run>
                                         <cmd>redis-server --appendonly yes</cmd>
                                         <wait>
-                                            <log>The server is now ready to accept connections</log>
+                                            <log>Ready to accept connections</log>
                                             <time>20000</time>
                                         </wait>
                                         <log>


### PR DESCRIPTION
Quick fix: Waiting for logs to detach the container. Changed log message.

Log message changed because redis is pulled from latest version.

Need to change the fix to make the redis start with a script or as
a service.